### PR TITLE
Update CROWPANEL_7_0.h board definition to work with EK9716B

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_Display_Panel
-version=0.1.5
+version=0.1.6
 author=espressif
 maintainer=espressif
 sentence=ESP32_Display_Panel is an Arduino library designed for ESP SoCs to drive display panels and facilitate rapid GUI development.

--- a/src/ESP_PanelVersions.h
+++ b/src/ESP_PanelVersions.h
@@ -11,7 +11,7 @@
 /* Library Version */
 #define ESP_PANEL_VERSION_MAJOR 0
 #define ESP_PANEL_VERSION_MINOR 1
-#define ESP_PANEL_VERSION_PATCH 5
+#define ESP_PANEL_VERSION_PATCH 6
 
 /* File `ESP_Panel_Conf.h` */
 #define ESP_PANEL_CONF_VERSION_MAJOR 0

--- a/src/board/elecrow/CROWPANEL_7_0.h
+++ b/src/board/elecrow/CROWPANEL_7_0.h
@@ -18,7 +18,7 @@
 /**
  * LCD Controller Name.
  */
-#define ESP_PANEL_LCD_NAME          EK9716BD3
+#define ESP_PANEL_LCD_NAME          EK9716B // Fitipower EK9716B
 
 /* LCD resolution in pixels */
 #define ESP_PANEL_LCD_WIDTH         (800)


### PR DESCRIPTION
Update CROWPANEL_7_0.h board definition to work with newly added support for Fitipower EK9716B LCD controller.
